### PR TITLE
Added pick and omit

### DIFF
--- a/02-javascript-data-types/2-pick/index.js
+++ b/02-javascript-data-types/2-pick/index.js
@@ -5,5 +5,12 @@
  * @returns {object} - returns the new object
  */
 export const pick = (obj, ...fields) => {
+  const res = {};
 
+  for (const prop of fields) {
+    if (obj.hasOwnProperty(prop)) {
+      res[prop] = obj[prop];
+    }
+  }
+  return res;
 };

--- a/02-javascript-data-types/3-omit/index.js
+++ b/02-javascript-data-types/3-omit/index.js
@@ -5,5 +5,12 @@
  * @returns {object} - returns the new object
  */
 export const omit = (obj, ...fields) => {
+  const res = {};
 
+  for (const [key, value] of Object.entries(obj)) {
+    if (!fields.includes(key)) {
+      res[key] = value;
+    }
+  }
+  return res;
 };


### PR DESCRIPTION
I know that there are many ways to do pick and omit, as well as both function can be the same. Decided to make it different for learn purpose. By the way the fastest way is reduce, but for me it's not easy to read
const pick1 = (obj, ...fields) => fields.reduce((acc, field) => (obj.hasOwnProperty(field) && (acc[field] = obj[field]), acc), {});
